### PR TITLE
Fix direct URL relative destination not resolved against DOWNLOADS_DIR

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -3551,8 +3551,13 @@ def _run_direct_url_with_cli(
     if not url or not isinstance(url, str):
         raise ValueError("single_url is required")
 
-    # Resolve destination (default to configured DOWNLOADS_DIR)
-    dest_dir = (destination or DOWNLOADS_DIR).strip() if destination else DOWNLOADS_DIR
+    # Resolve destination (default to configured DOWNLOADS_DIR).
+    # Relative paths are resolved against DOWNLOADS_DIR, matching the job queue path.
+    if destination:
+        raw = destination.strip()
+        dest_dir = raw if os.path.isabs(raw) else os.path.join(str(DOWNLOADS_DIR), raw)
+    else:
+        dest_dir = str(DOWNLOADS_DIR)
     ensure_dir(dest_dir)
 
     # Direct URL runs are intentionally NOT persisted into the unified download_jobs queue.


### PR DESCRIPTION
## Summary

- `_run_direct_url_with_cli` receives `destination` from the UI as a relative path (e.g. `Singles`) but passed it directly to `ensure_dir()` and `finalize_download_artifact()`, causing `os.makedirs` to resolve it against the process CWD (`/app`) instead of `DOWNLOADS_DIR` (`/downloads`)
- When running as a non-root user this raises `PermissionError: [Errno 13] Permission denied: 'Singles'`; when running as root it silently writes files inside the container rather than the mounted downloads volume
- The job queue path correctly calls `resolve_dir(raw, paths.single_downloads_dir)` for this reason — this fix applies the same logic to the direct URL CLI path

## Test plan

- [ ] Submit a direct URL (e.g. Facebook reel) with a relative `single_download_folder` configured (e.g. `Singles`) — file should land in `$DOWNLOADS_DIR/Singles/` instead of erroring
- [ ] Submit a direct URL with no destination set — file should land in `$DOWNLOADS_DIR/` as before
- [ ] Submit a direct URL with an absolute destination — should still work unchanged