### PR TITLE
allowlist replace_in_metadata in yt_dlp_opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented here.
 
+## Unreleased
+
+### Added
+- `replace_in_metadata` is now allowlisted in `yt_dlp_opts`, letting users pass yt-dlp's metadata regex-substitution post-processor option through config to strip noise from titles (e.g. remaster or channel-name suffixes) without affecting download behavior.
+
 ## v1.0.0 — ARR Stack, Movies & TV, and Music Player Milestone
 
 ### High-Level
@@ -40,7 +45,6 @@ Retreivr 1.0.0 is the first major release and the biggest product expansion so f
 - Music player failure handling now marks unresolved queue items, skips forward where possible, and uses non-blocking notices instead of hard-stop playback failures.
 - Artist/album/player interactions and browse-card click handling were tightened after the expanded Music and Movies/TV UI work.
 - Test/runtime artifact paths were hardened so test runs do not recreate tracked `/data` or `/tests` artifacts.
-
 
 ## v0.9.20 — Community Cache Publish Reset Endpoint Fix
 

--- a/engine/job_queue.py
+++ b/engine/job_queue.py
@@ -155,6 +155,7 @@ _YTDLP_DOWNLOAD_ALLOWLIST = {
     "noproxy",
     "proxy",
     "ratelimit",
+    "replace_in_metadata",
     "retries",
     "sleep_interval",
     "socket_timeout",

--- a/engine/job_queue.py
+++ b/engine/job_queue.py
@@ -165,6 +165,7 @@ _YTDLP_DOWNLOAD_ALLOWLIST = {
     "noproxy",
     "proxy",
     "ratelimit",
+    "replace_in_metadata",
     "retries",
     "sleep_interval",
     "socket_timeout",

--- a/tests/test_ytdlp_download_opts.py
+++ b/tests/test_ytdlp_download_opts.py
@@ -83,6 +83,20 @@ class YtdlpDownloadOptsTests(unittest.TestCase):
             self.assertNotIn(key, opts)
         self.assertEqual(opts.get("socket_timeout"), 10)
 
+    def test_replace_in_metadata_passes_through(self):
+        context = {
+            "operation": "download",
+            "audio_mode": False,
+            "final_format": None,
+            "audio_only": False,
+            "config": {},
+            "overrides": {
+                "replace_in_metadata": [["title", r"\s+\(.*?\)$", ""]],
+            },
+        }
+        opts = build_ytdlp_opts(context)
+        self.assertIn("replace_in_metadata", opts)
+
     def test_video_mp4_target_sets_postprocess_conversion(self):
         context = {
             "operation": "download",


### PR DESCRIPTION
## What

Adds `replace_in_metadata` to `_YTDLP_DOWNLOAD_ALLOWLIST` so it can be passed via `yt_dlp_opts` in config.

## Why

`replace_in_metadata` is a yt-dlp post-processor option that rewrites metadata fields using regex substitution (e.g. stripping remaster suffixes or channel name suffixes from titles). It doesn't affect the download itself — it only transforms metadata — so it's safe to allowlist alongside options like `ratelimit` and `retries`.

Without this, users who set `replace_in_metadata` in `yt_dlp_opts` have it silently dropped.

## Test

Added a test to `tests/test_ytdlp_download_opts.py` verifying the option passes through `build_ytdlp_opts` for download operations.