### PR TITLE
Use resolve_dir for direct URL destination (follow-up to #19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 .DS_Store
 .vscode/
 _project_management/
+.venv/

--- a/api/main.py
+++ b/api/main.py
@@ -3551,13 +3551,9 @@ def _run_direct_url_with_cli(
     if not url or not isinstance(url, str):
         raise ValueError("single_url is required")
 
-    # Resolve destination (default to configured DOWNLOADS_DIR).
-    # Relative paths are resolved against DOWNLOADS_DIR, matching the job queue path.
-    if destination:
-        raw = destination.strip()
-        dest_dir = raw if os.path.isabs(raw) else os.path.join(str(DOWNLOADS_DIR), raw)
-    else:
-        dest_dir = str(DOWNLOADS_DIR)
+    # Match the queue path: resolve_dir handles empty/relative/absolute and rejects
+    # destinations that escape the base via inputs like "../etc".
+    dest_dir = resolve_dir((destination or "").strip(), paths.single_downloads_dir)
     ensure_dir(dest_dir)
 
     # Direct URL runs are intentionally NOT persisted into the unified download_jobs queue.

--- a/tests/test_direct_url_contracts.py
+++ b/tests/test_direct_url_contracts.py
@@ -31,6 +31,7 @@ def api_module(monkeypatch, tmp_path: Path):
         db_path=str(db_path),
         temp_downloads_dir=str(temp_dir),
         thumbs_dir=str(thumbs_dir),
+        single_downloads_dir=str(tmp_path),
     )
     module.app.state.state = "idle"
     module.app.state.current_download_proc = None
@@ -143,6 +144,89 @@ def test_server_direct_url_video_mode_uses_video_template_and_container_policy(
     assert len(files) == 1
     assert files[0].startswith("VID-Video Title__Channel Name.")
     assert files[0].endswith(".mkv")
+
+
+def test_server_direct_url_relative_destination_resolves_under_downloads_dir(
+    api_module, monkeypatch, tmp_path: Path
+) -> None:
+    module = api_module
+    module.app.state.paths.single_downloads_dir = str(tmp_path / "downloads_root")
+    Path(module.app.state.paths.single_downloads_dir).mkdir(parents=True, exist_ok=True)
+    config = {
+        "final_format": "mkv",
+        "filename_template": "VID-%(title)s.%(ext)s",
+    }
+
+    def _fake_download_with_ytdlp(url, temp_dir, config_arg, **kwargs):
+        _ = config_arg, kwargs
+        output = Path(temp_dir) / "payload.mkv"
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_bytes(b"video")
+        return {
+            "id": "abc123xyz99",
+            "title": "Video Title",
+            "uploader": "Channel",
+            "webpage_url": url,
+        }, str(output)
+
+    monkeypatch.setattr(module, "get_loaded_config", lambda: config)
+    monkeypatch.setattr(module, "download_with_ytdlp", _fake_download_with_ytdlp)
+    monkeypatch.setattr(module, "embed_metadata", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "_record_direct_url_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(module, "ensure_mb_bound_music_track", lambda *args, **kwargs: None)
+
+    module._run_direct_url_with_cli(
+        url="https://youtu.be/-LI8X-GhFA8",
+        paths=module.app.state.paths,
+        config=config,
+        destination="Singles",
+        final_format_override="mkv",
+        media_type="video",
+        media_intent="episode",
+        music_mode=False,
+        stop_event=threading.Event(),
+        status=None,
+    )
+
+    singles_dir = Path(module.app.state.paths.single_downloads_dir) / "Singles"
+    files = [p.name for p in singles_dir.glob("*") if p.is_file()]
+    assert len(files) == 1
+    assert files[0].startswith("VID-Video Title.")
+    assert files[0].endswith(".mkv")
+
+
+def test_server_direct_url_escape_destination_is_rejected(
+    api_module, monkeypatch, tmp_path: Path
+) -> None:
+    module = api_module
+    module.app.state.paths.single_downloads_dir = str(tmp_path / "downloads_root")
+    Path(module.app.state.paths.single_downloads_dir).mkdir(parents=True, exist_ok=True)
+    config = {"final_format": "mkv"}
+
+    called = {"download": False}
+
+    def _fake_download_with_ytdlp(*args, **kwargs):
+        called["download"] = True
+        raise AssertionError("download_with_ytdlp should not be called for escape destinations")
+
+    monkeypatch.setattr(module, "get_loaded_config", lambda: config)
+    monkeypatch.setattr(module, "download_with_ytdlp", _fake_download_with_ytdlp)
+
+    with pytest.raises(ValueError, match="within base directory"):
+        module._run_direct_url_with_cli(
+            url="https://youtu.be/-LI8X-GhFA8",
+            paths=module.app.state.paths,
+            config=config,
+            destination="../../etc",
+            final_format_override="mkv",
+            media_type="video",
+            media_intent="episode",
+            music_mode=False,
+            stop_event=threading.Event(),
+            status=None,
+        )
+
+    assert called["download"] is False
 
 
 def test_client_direct_url_music_mode_is_rejected(api_module) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #19 addressing @loganbuilt's [review comment](https://github.com/sudoStacks/retreivr/pull/19#issuecomment-4208605119):

- `_run_direct_url_with_cli` now calls `resolve_dir((destination or "").strip(), paths.single_downloads_dir)` instead of doing its own `os.path.isabs` / `os.path.join` dance — matches the queue path in `engine/job_queue.py:_resolve_job_output_dir`.
- Destinations that escape the base (e.g. `../etc`) now raise `ValueError` instead of silently resolving outside `DOWNLOADS_DIR`.
- Adds two regression tests in `tests/test_direct_url_contracts.py`:
  - relative destination `"Singles"` lands under `single_downloads_dir/Singles/`
  - escape destination `"../../etc"` is rejected and `download_with_ytdlp` is never invoked

## Known test-environment issue

On a fresh process under Python 3.11.15 the new tests (and the rest of `test_direct_url_contracts.py`) fail at fixture setup with:

```
ValueError: failed to parse CPython sys.version: '3.11.9'
```

This comes from `platform._sys_version_parser` choking on the bare `"3.11.9"` string installed by the existing `monkeypatch.setattr(sys, "version", "3.11.9", ...)` line in the `api_module` fixture, after `wsgiref.simple_server` is imported transitively via `google_auth_oauthlib` during `api.main` import. Whether it triggers depends on whether `wsgiref.simple_server` was already cached in `sys.modules` before the fixture runs. The same `monkeypatch` pattern is used in ~19 fixtures across `tests/`, so this isn't unique to this file.

Not touching the fixture in this PR to keep the diff focused on the review comment. Planning a follow-up PR to bring the full test suite under GitHub Actions; once CI is running the whole `test_*` family we can fix the fixture pattern once for everyone.

Separately, two pre-existing tests in this file (`test_*_video_mode_*`) fail on `main` with a `final_format` assertion mismatch (`'mp3' != 'mkv'`), unrelated to this change — left untouched.

## Test plan

- [x] `pytest tests/test_direct_url_contracts.py::test_server_direct_url_relative_destination_resolves_under_downloads_dir` — passes in environments where the fixture's `sys.version` patch doesn't break `wsgiref` import
- [x] `pytest tests/test_direct_url_contracts.py::test_server_direct_url_escape_destination_is_rejected` — same caveat
- [ ] Manual: submit a direct URL with `single_download_folder="Singles"` → file in `$DOWNLOADS_DIR/Singles/`
- [ ] Manual: submit a direct URL with `destination="../outside"` → rejected with a clear error