### PR TITLE
Add CI workflow to run pytest on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio httpx
+
+      - name: Run pytest
+        run: |
+          pytest -q

--- a/tests/test_provenance_version.py
+++ b/tests/test_provenance_version.py
@@ -7,7 +7,7 @@ def test_get_retreivr_version_falls_back_to_pyproject(monkeypatch) -> None:
     monkeypatch.delenv("RETREIVR_VERSION", raising=False)
     monkeypatch.setattr(provenance.importlib_metadata, "version", lambda _name: (_ for _ in ()).throw(Exception("missing")))
 
-    assert provenance.get_retreivr_version() == "0.9.20"
+    assert provenance.get_retreivr_version() == "1.0.0"
 
 
 def test_get_retreivr_version_prefers_env(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tests.yml` running the full pytest suite on Python 3.11
- Triggers on every PR, on pushes to `main`, and via `workflow_dispatch`
- Installs runtime deps from `requirements.txt` plus `pytest`, `pytest-asyncio`, `httpx` (needed by FastAPI `TestClient`)

## Why
No general CI workflow runs the suite today — only `music-search-benchmark` and release workflows. Running pytest on every PR catches regressions and gates the release branch.

## Gating
Requires all tests to pass — no `continue-on-error`, so any failure fails the check. Fixed one pre-existing broken test (`tests/test_provenance_version.py`, expected `0.9.20` → `1.0.0`) to meet this requirement.

## Test plan
- [x] Full suite passes on this branch (605 passed, 1 skipped)
- [x] Failures fail the check (no `continue-on-error`)
- [ ] Workflow appears on the PR and runs to completion
- [ ] Subsequent PRs trigger the workflow automatically
